### PR TITLE
Add MonitorUtility.add method

### DIFF
--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from sqlalchemy import select
 
-from orm import User, Whitelist, db
+from orm import User, Whitelist, DBConnection
 
 
 class MonitorUtility:
@@ -18,10 +18,16 @@ class MonitorUtility:
             url: The URL of the application database
         """
 
-        db.configure(url)
+        self.db = DBConnection()
+        self.db.configure(url)
 
-    @staticmethod
-    def add(user: str, duration: Optional[timedelta] = None, node: Optional[str] = None, _global: bool = False) -> None:
+    def add(
+            self,
+            user: str,
+            duration: Optional[timedelta] = None,
+            node: Optional[str] = None,
+            _global: bool = False
+    ) -> None:
         """Whitelist a user to prevent their processes from being killed
 
         Args:
@@ -34,7 +40,7 @@ class MonitorUtility:
         if node is None and not _global:
             raise ValueError('Must either specify a node name or set global to True.')
 
-        with db.session() as session:
+        with self.db.session() as session:
             # Create a record for the user if it does not already exist
             user_query = select(User).where(User.name == user)
             user_record = session.execute(user_query).scalars().first()

--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -11,7 +11,7 @@ from orm import User, Whitelist, DBConnection
 class MonitorUtility:
     """Monitor system resource usage and manage currently running processes"""
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str = 'sqlite:///monitor.db') -> None:
         """Configure the parent application
 
         Args:

--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -5,11 +5,20 @@ from typing import Optional
 
 from sqlalchemy import select
 
-from orm import User, Whitelist
+from orm import User, Whitelist, db
 
 
 class MonitorUtility:
     """Monitor system resource usage and manage currently running processes"""
+
+    def __init__(self, url: str) -> None:
+        """Configure the parent application
+
+        Args:
+            url: The URL of the application database
+        """
+
+        db.configure(url)
 
     @staticmethod
     def add(user: str, duration: Optional[timedelta] = None, node: Optional[str] = None, _global: bool = False) -> None:
@@ -25,7 +34,7 @@ class MonitorUtility:
         if node is None and not _global:
             raise ValueError('Must either specify a node name or set global to True.')
 
-        with Session() as session:
+        with db.session() as session:
             # Create a record for the user if it does not already exist
             user_query = select(User).where(User.name == user)
             user_record = session.execute(user_query).scalars().first()

--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 from sqlalchemy import select
 
-from orm import User, Whitelist, DBConnection
+from .orm import User, Whitelist, DBConnection
 
 
 class MonitorUtility:

--- a/node_nanny/orm.py
+++ b/node_nanny/orm.py
@@ -1,6 +1,6 @@
 """Object relational mapper for dealing with the application database."""
 
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, Boolean
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -67,7 +67,8 @@ class Whitelist(Base):
     __tablename__ = 'whitelist'
 
     id = Column(Integer, primary_key=True, autoincrement=True)
-    node = Column(String, nullable=False)
+    node = Column(String)
     termination = Column(DateTime)
+    global_whitelist = Column(Boolean, default=False)
 
     user = relationship('User', back_populates='whitelists')

--- a/tests/app/test_monitor_utility.py
+++ b/tests/app/test_monitor_utility.py
@@ -1,0 +1,16 @@
+"""Tests for the ``MonitorUtility`` class."""
+
+from unittest import TestCase
+
+from node_nanny.app import MonitorUtility
+
+
+class AddUserToWhitelist(TestCase):
+    """Test the addition of users to the whitelist"""
+
+    def test_error_on_missing_node(self) -> None:
+        """Test for value error on missing node name when global is False"""
+
+        app = MonitorUtility('sqlite:///:memory:')
+        with self.assertRaises(ValueError):
+            app.add('test_user', node=None, _global=False)


### PR DESCRIPTION
This PR introduces the `MonitorUtility.add` method.

The new code requires the `DBConnection` class introduced by PR #21. This PR is blocked until #21 is approved. In the meantime, I've treated the `DBConnection` class as its defined in the UML architecture diagram.

#### Things that are unfinished:

1. The add method creates a new DB record every time it is called. This makes it possible for duplicate records to be created. I propose revisiting this problem in the future.
2. The tests I've written are a bit bare bones. However, since I'm proposing we revisit this method anyways, I propose we flesh them out at the same time we address the bullet point above.