### PR TITLE
Add MonitorUtility.remove method

### DIFF
--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -36,7 +36,6 @@ class MonitorUtility:
         Args:
             user: The name of the user
             duration: How long to whitelist the user for
-
             node: The name of the node
             _global: Whitelist the user on all nodes
         """
@@ -49,7 +48,7 @@ class MonitorUtility:
         duration = duration or timedelta(days=one_hundred_years_in_days)
 
         with self._db.session() as session:
-            # Create a record for the user if it does not already exist
+            # Create a record for the user if it doesn't not already exist
             user_query = select(User).where(User.name == user)
             user_record = session.execute(user_query).scalars().first()
             if user_record is None:
@@ -93,7 +92,7 @@ class MonitorUtility:
             query = query.where(Whitelist.node == node)
 
         now = datetime.now()
-        with DBConnection.session() as session:
+        with self._db.session() as session:
             for record in session.execute(query).scalars().all():
                 record.end_time = now
                 session.add(record)
@@ -101,7 +100,7 @@ class MonitorUtility:
             session.commit()
 
     @staticmethod
-    def kill(user):
+    def kill(user: str) -> None:
         """Terminate all processes launched by a given user"""
 
         user_processes = SystemUsage.user_usage(user)

--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -1,0 +1,36 @@
+"""The ``app`` module defines the core application logic."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+
+from .orm import User, Whitelist, DBConnection
+
+
+class MonitorUtility:
+    """Monitor system resource usage and manage currently running processes"""
+
+    def remove(self, user: str, node: Optional[str], _global: bool = False) -> None:
+        """Remove a user from the application whitelist
+
+        Args:
+            user: The name of the user
+            node: The name of the node
+            _global: Whitelist the user on all nodes
+        """
+
+        if node is None and not _global:
+            raise ValueError('Must either specify a node name or set global to True.')
+
+        query = select(Whitelist).join(User).where(User.name == user)
+        if node:
+            query = query.where(Whitelist.node == node)
+
+        now = datetime.now()
+        with DBConnection.session() as session:
+            for record in session.execute(query).scalars().all():
+                record.end_time = now
+                session.add(record)
+
+            session.commit()


### PR DESCRIPTION
Instead of removing old records from the database, I've implemented the method to set the end time of the whitelist record to the present time. This will stop a user's jobs from being whitelisted while maintaining their whitelist history. 