### PR TITLE
Impliment MonitorUtility.whitelist

### DIFF
--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -39,6 +39,9 @@ class MonitorUtility:
 
         # Execute the query with pandas and rely on the default DataFrame string representation
         whitelist_df = pd.read_sql(query, con=self._db.engine).set_index(['User', 'Global'])
+        whitelist_df.Start = whitelist_df.Start.dt.round('1s')
+        whitelist_df.End = whitelist_df.Start.dt.round('1s')
+
         print(whitelist_df)
 
     def add(

--- a/node_nanny/app.py
+++ b/node_nanny/app.py
@@ -37,8 +37,9 @@ class MonitorUtility:
             .select_from(User).join(Whitelist) \
             .where(Whitelist.end_time > datetime.now())
 
-        whitelist_df = pd.read_sql(query, con=self._db.engine).set_index('User')
-        print(whitelist_df.to_markdown())
+        # Execute the query with pandas and rely on the default DataFrame string representation
+        whitelist_df = pd.read_sql(query, con=self._db.engine).set_index(['User', 'Global'])
+        print(whitelist_df)
 
     def add(
             self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 psutil
 sqlalchemy
+tabulate


### PR DESCRIPTION
A basic implementation of the `MonitorUtility.whitelist` method.

I'm executing the query via `pandas` and relying on the built-in string representation of `Dataframe` objects to format the output.

We haven't specified a design for the printed output of the function. Using the default pandas format is certainly easy, but that doesn't necessarily mean it's optimal. If there are ideas for improvements, I'm open to suggestions.